### PR TITLE
Allow different codings in syncerror details

### DIFF
--- a/docs/events/syncerror.md
+++ b/docs/events/syncerror.md
@@ -45,6 +45,7 @@ Key | Optionality | Fhir operation to generate context | Description
                   {
                     "system": "https://customdomain.com/events/syncerror/description",
                     "code": "FHIRcast sync error"
+                  }
                 ]
               }
             }

--- a/docs/events/syncerror.md
+++ b/docs/events/syncerror.md
@@ -12,7 +12,7 @@ Unlike most of FHIRcast events, `syncerror` is an infrastructural event and does
 
 Key | Optionality | Fhir operation to generate context | Description
 ----- | -------- | ---- | ---- 
-`operationoutcome` | OPTIONAL | `OperationOutcome` | FHIR resource describing an outcome of an unsuccessful system action. The OperationOutcome SHALL use a code of processing. The OperationOutcome's `details.coding.code` SHALL contain the id of the event that this error is related to.
+`operationoutcome` | OPTIONAL | `OperationOutcome` | FHIR resource describing an outcome of an unsuccessful system action. The OperationOutcome SHALL use a code of processing. The OperationOutcome's `details.coding.code` SHALL contain the id of the event that this error is related to as a `code` with the `system` value of "https://fhircast.hl7.org/events/syncerror/eventid". Other `coding` values can be included with different `system` values so as to include extra information about the `syncerror`.
 
 
 
@@ -39,8 +39,12 @@ Key | Optionality | Fhir operation to generate context | Description
               "details": {
                 "coding": [
                   {
+                    "system": "https://fhircast.hl7.org/events/syncerror/eventid",
                     "code": "fdb2f928-5546-4f52-87a0-0648e9ded065"
-                  }
+                  },
+                  {
+                    "system": "https://customdomain.com/events/syncerror/description",
+                    "code": "FHIRcast sync error"
                 ]
               }
             }

--- a/docs/events/syncerror.md
+++ b/docs/events/syncerror.md
@@ -43,7 +43,7 @@ Key | Optionality | Fhir operation to generate context | Description
                     "code": "fdb2f928-5546-4f52-87a0-0648e9ded065"
                   },
                   {
-                    "system": "https://customdomain.com/events/syncerror/description",
+                    "system": "http://example.com/events/syncerror/your-error-code-system",
                     "code": "FHIRcast sync error"
                   }
                 ]

--- a/docs/specification/STU2.md
+++ b/docs/specification/STU2.md
@@ -462,7 +462,7 @@ Field | Optionality | Type | Description
 --- | --- | --- | ---
 `hub.topic` | Required | string | The session topic given in the subscription request. 
 `hub.event`| Required | string | Shall be the string `syncerror`.
-`context` | Required | array | An array containing a single FHIR OperationOutcome. The OperationOutcome SHALL use a code of `processing`. The OperationOutcome's details SHALL contain the id of the event that this error is related to. 
+`context` | Required | array | An array containing a single FHIR OperationOutcome. The OperationOutcome SHALL use a code of `processing`. The OperationOutcome's details SHALL contain the id of the event that this error is related to as a `code` with the `system` value of "https://fhircast.hl7.org/events/syncerror/eventid". Other `coding` values can be included with different `system` values so as to include extra information about the `syncerror`.
 
 ### Event Notification Error Example
 
@@ -491,6 +491,7 @@ Content-Type: application/json
               "details": {
                 "coding": [
                   {
+                    "system": "https://fhircast.hl7.org/events/syncerror/eventid",
                     "code": "fdb2f928-5546-4f52-87a0-0648e9ded065"
                   }
                 ]


### PR DESCRIPTION
Doesn't fix a specific Jira issue, but enhances sync error to allow extra details beyond just the event id.