### PR TITLE
Ballot cleanup

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -5,7 +5,3 @@ The Implementation Guide contains no examples for this profile
 
 # We believe that this error is caused by infrastructure, not by the content of this IG. See cpb-15's xpath.
 value should not start or finish with whitespace ' not(f:kind/@value='instance')...exists(f:software))'
-
-
-# Code system URI is in an example
-Code System URI 'http://www.radlex.org' is unknown so the code cannot be validated

--- a/input/jira/FHIR-fhircast.xml
+++ b/input/jira/FHIR-fhircast.xml
@@ -8,7 +8,7 @@
                gitUrl="https://github.com/HL7/fhircast-docs" 
                url="http://hl7.org/fhir/uv/fhircast-docs">
  
-<version code="current" url="https://build.fhir.org/ig/HL7/fhircast-docs/"/>
+<version code="current" url="http://build.fhir.org/ig/HL7/fhircast-docs/"/>
 <version code="2.0.0" deprecated="true" url="https://fhircast.org/specification/STU2/"/>
 <version code="1.0.0" deprecated="true" url="https://fhircast.org/specification/STU1/"/>
 <artifactPageExtension value="-definitions"/>

--- a/input/jira/FHIR-fhircast.xml
+++ b/input/jira/FHIR-fhircast.xml
@@ -2,7 +2,7 @@
 <specification 
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
                ballotUrl="http://hl7.org/fhir/uv/fhircast-docs/2022May" 
-               ciUrl="https://build.fhir.org/ig/HL7/fhircast-docs" 
+               ciUrl="http://build.fhir.org/ig/HL7/fhircast-docs" 
                defaultVersion="3.0.0" 
                defaultWorkgroup="inm" 
                gitUrl="https://github.com/HL7/fhircast-docs" 

--- a/package-list.json
+++ b/package-list.json
@@ -6,24 +6,26 @@
     "list": [
       {
         "version": "current",
-        "descmd": "Continuous Integration Build (latest in version control)",
-        "path": "https://build.fhir.org/ig/HL7/fhircast-docs",
+        "path": "'http://hl7.org/fhir/uv/fhircast-docs",
+        "desc": "Continuous Integration Build (latest in version control)",
+        "sequence": "STU3",
+        "fhirversion": "4.0.1",
         "status": "ci-build",
-        "current" : true
-      },
+        "current": true,
+        "date": "2022-03-24"
+        },
       {
         "version": "1.2.0-ballot",
         "desc": "Ballot for STU Release 3",
         "status": "ballot",
         "sequence": "STU3",
         "fhirversion": "4.0.1",
-        "path": "http://hl7.org/fhir/uv/fhircast/2022May",
-        "date": "2022-05-01",
-        "current" : true
+        "path": "http://hl7.org/fhir/uv/fhircast-docs/2022May",
+        "date": "2022-05-01"
       },
       {
-        "version": "STU2",
-        "desc": "STU 2 Publication",
+        "version": "1.1.0",
+        "desc": "STU2 Publication",
         "status": "trial-use",
         "sequence": "STU2",
         "fhirversion": "4.0.1",
@@ -32,7 +34,7 @@
         "current": true
       },	 
       {
-        "version": "STU1",
+        "version": "1.0.0",
         "desc": "Standard for Trial Use (STU1) This is the 1.0 release of the FHIRcast specification.",
         "status": "trial-use",
         "sequence": "STU1",


### PR DESCRIPTION
I don't know what changes caused a merge conflict but with these changes I got down to:

Code = fhircast. package-list.json entry for vcurrent: must have a 'path' that starts with the canonical (is ''http://hl7.org/fhir/uv/fhircast-docs', should start with 'http://hl7.org/fhir/uv/fhircast'

in the publication rules section of the qa report.