### PR TITLE
Update FHIR-fhircast.xml

### DIFF
--- a/input/jira/FHIR-fhircast.xml
+++ b/input/jira/FHIR-fhircast.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/uv/fhircast/2022May" ciUrl="http://hl7.org/fhir/uv/fhircast" defaultVersion="2.0.0" defaultWorkgroup="inm" gitUrl="https://github.com/HL7/fhircast-docs" url="http://hl7.org/fhir/uv/fhircast">
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+               ballotUrl="http://hl7.org/fhir/uv/fhircast/2022May"
+               ciUrl="http://build.fhir.org/ig/HL7/fhircast-docs" 
+               defaultVersion="2.0.0" defaultWorkgroup="inm" 
+               gitUrl="https://github.com/HL7/fhircast-docs" 
+               url="http://build.fhir.org/ig/HL7/fhircast-docs">
 <version code="current" url="http://hl7.org/fhir/uv/fhircast"/>
 <version code="2.1.0-ballot" url="http://hl7.org/fhir/uv/fhircast/2022May"/>
 <version code="2.0.0" url="https://fhircast.hl7.org/specification/STU2/"/>


### PR DESCRIPTION
per Lynns email:
<specification xmlns:xsi=http://www.w3.org/2001/XMLSchema-instance ballotUrl=http://hl7.org/fhir/uv/fhircast/2022May ciUrl= **http://build.fhir.org/ig/HL7/fhircast-docs**  defaultVersion="2.0.0" defaultWorkgroup="inm" gitUrl=https://github.com/HL7/fhircast-docs url= **http://build.fhir.org/ig/HL7/fhircast-docs** >