### PR TITLE
Add SUSHI and IG publisher validation to PRs and commits

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,40 @@
+name: validate
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  sushi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Validate with Sushi
+        run: sushi .
+
+  ig-publisher:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Jekyll
+        run: sudo gem install jekyll
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+      
+      - name: Install IG publisher
+        run: |
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+
+      - name: Validate IG
+        run: |
+          chmod +x ./_genonce.sh
+          ./_genonce.sh


### PR DESCRIPTION
This improvement makes use of Github's CI/CD capabilities to automatically validate PRs and commits, both with SUSHI and the IG publisher automatically. 

This ensures that incoming improvements don't have build-breaking changes, and maintainers gain a degree of assurance.

Once this is merged, checks will appear at the bottom of the PR:

<img width="923" alt="image" src="https://user-images.githubusercontent.com/110988/199988136-8d9c9522-087b-4584-9b65-8b675a707410.png">
 
as well as within the `Checks` tab:

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/110988/199988279-874084ea-868e-4134-b9f7-ff9167e04ed6.png">
