### PR TITLE
FHIR-40445

### DIFF
--- a/input/pagecontent/3-6-3-DiagnosticReport-update.md
+++ b/input/pagecontent/3-6-3-DiagnosticReport-update.md
@@ -7,17 +7,17 @@ eventMaturity | [2 - Tested](3-1-2-eventmaturitymodel.html)
 The updates include:
 
 * adding, updating, or removing FHIR resources contained in the DiagnosticReport
-* updating attributes of the DiagnosticReport or associated context resources (Patient and/or ImagingStudy resources)
+* updating attribute values of the DiagnosticReport or associated context resources (Patient and/or ImagingStudy resources)
 
 #### Context
 
 {:.grid}
-Key | Optionality | FHIR operation to generate context | Description
---- | --- | --- | ---
-`report`| REQUIRED | `DiagnosticReport/{id}?_elements=identifier` | Anchor context
-`patient` | OPTIONAL | `Patient/{id}?_elements=identifier` | Present if one or more attributes in the Patient resource associated with the report have changed
-`study` | OPTIONAL | `ImagingStudy/{id}?_elements=identifier,accession` | Present if one or more attributes in the ImagingStudy resource associated with the report have changed
-`updates` | REQUIRED | not applicable | Changes to be made to the current content of the anchor context
+Key | Cardinality | FHIR operation to generate context | Description
+----- | -------- | ---- | ---- 
+`report` | 1..1 | `DiagnosticReport/{id}?_elements=identifier` | FHIR DiagnosticReport resource specifying the [`anchor context`](5_glossary.html) in which the update is being made.  Note that only the resource.resourceType and resource.id of the [`anchor context`](5_glossary.html) are required to be present.  Other attributes may be present in the DiagnosticReport resource if their values have changed or were newly populated.
+`patient` | 0..1 | `Patient/{id}?_elements=identifier` | Present if one or more attributes in the Patient resource associated with the report have changed.
+`study` | 0..1 | `ImagingStudy/{id}?_elements=identifier,accession` | Present if one or more attributes in the ImagingStudy resource associated with the report have changed
+`updates` | 1..1 | not applicable | Contains a single `Bundle` resource holding changes to be made to the current content of the [`anchor context`](5_glossary.html)
 
 #### Supported Update Request Methods
 
@@ -26,8 +26,7 @@ Each `entry` in the `updates` Bundle resource must contain one of the below `met
 {:.grid}
 Request Method | Operation
 --- | ---
-`POST` | Add a new resource
-`PUT` | Replace/update an existing resource
+`PUT` | Add a new resource or update a resource already existing in the content
 `DELETE` | Remove an existing resource
 
 #### Examples
@@ -41,7 +40,7 @@ The following example shows adding an imaging study to the existing diagnostic r
   "timestamp": "2019-09-10T14:58:45.988Z",
   "id": "0d4c7776",
   "event": {
-    "hub.topic": "DrXRay",
+    "hub.topic": "fdb2f928-5546-4f52-87a0-0648e9ded065",
     "hub.event": "DiagnosticReport-update",
     "context.versionId": "b9574cb0-e9e5-4be1-8957-5fcb51ef33c1",
     "context": [
@@ -49,14 +48,13 @@ The following example shows adding an imaging study to the existing diagnostic r
         "key": "report",
         "resource": {
           "resourceType": "DiagnosticReport",
-          "id": "40012366"
+          "id": "2402d3bd-e988-414b-b7f2-4322e86c9327"
         }
       },
       {
         "key": "updates",
         "resource": {
           "resourceType": "Bundle",
-          "id": "8i7tbu6fby5fuuey7133eh",
           "type": "transaction",
           "entry": [
             {
@@ -67,7 +65,7 @@ The following example shows adding an imaging study to the existing diagnostic r
                 "resourceType": "ImagingStudy",
                 "description": "CHEST XRAY",
                 "started": "2010-02-14T01:10:00.000Z",
-                "id": "3478116342",
+                "id": "7e9deb91-0017-4690-aebd-951cef34aba4",
                 "identifier": [
                   {
                     "type": {
@@ -89,13 +87,13 @@ The following example shows adding an imaging study to the existing diagnostic r
             },
             {
               "request": {
-                "method": "POST"
+                "method": "PUT"
               },
               "resource": {
                 "resourceType": "Observation",
-                "id": "435098234",
+                "id": "40afe766-3628-4ded-b5bd-925727c013b3",
                 "partOf": {
-                  "reference": "ImagingStudy/3478116342"
+                  "reference": "ImagingStudy/e25c1d31-20a2-41f8-8d85-fe2fdeac74fd"
                 },
                 "status": "preliminary",
                 "category": {
@@ -130,9 +128,8 @@ The HUB SHALL distribute a corresponding event to all Subscribers. The Hub SHALL
 ```json
 {
   "timestamp": "2019-09-10T14:58:45.988Z",
-  "id": "0d4c7776",
   "event": {
-    "hub.topic": "DrXRay",
+    "hub.topic": "fdb2f928-5546-4f52-87a0-0648e9ded065",
     "hub.event": "DiagnosticReport-update",
     "context.versionId": "efcac43a-ed38-49e4-8d79-73f78290292a",
     "context.priorVersionId": "b9574cb0-e9e5-4be1-8957-5fcb51ef33c1",
@@ -141,14 +138,13 @@ The HUB SHALL distribute a corresponding event to all Subscribers. The Hub SHALL
         "key": "report",
         "resource": {
           "resourceType": "DiagnosticReport",
-          "id": "40012366"
+          "id": "2402d3bd-e988-414b-b7f2-4322e86c9327"
         }
       },
       {
         "key": "updates",
         "resource": {
           "resourceType": "Bundle",
-          "id": "8i7tbu6fby5fuuey7133eh",
           "type": "transaction",
           "entry": [
             {
@@ -159,7 +155,7 @@ The HUB SHALL distribute a corresponding event to all Subscribers. The Hub SHALL
                 "resourceType": "ImagingStudy",
                 "description": "CHEST XRAY",
                 "started": "2010-02-14T01:10:00.000Z",
-                "id": "3478116342",
+                "id": "7e9deb91-0017-4690-aebd-951cef34aba4",
                 "identifier": [
                   {
                     "type": {
@@ -181,13 +177,13 @@ The HUB SHALL distribute a corresponding event to all Subscribers. The Hub SHALL
             },
             {
               "request": {
-                "method": "POST"
+                "method": "PUT"
               },
               "resource": {
                 "resourceType": "Observation",
-                "id": "435098234",
+                "id": "40afe766-3628-4ded-b5bd-925727c013b3",
                 "partOf": {
-                  "reference": "ImagingStudy/3478116342"
+                  "reference": "ImagingStudy/e25c1d31-20a2-41f8-8d85-fe2fdeac74fd"
                 },
                 "status": "preliminary",
                 "category": {
@@ -221,3 +217,4 @@ The HUB SHALL distribute a corresponding event to all Subscribers. The Hub SHALL
 | Version | Description
 | ------- | ----
 | 0.1 | Initial draft
+| 1.0 | Updated for STU3

--- a/input/pagecontent/3-6-4-DiagnosticReport-select.md
+++ b/input/pagecontent/3-6-4-DiagnosticReport-select.md
@@ -3,7 +3,7 @@
 eventMaturity | [2 - Tested](3-1-2-eventmaturitymodel.html)
 
 ### Workflow
-A `DiagnosticReport-select` request will be made to the Hub when a Subscriber desires to indicate that one or more FHIR resources contained in the DiagnosticReport context's content are to be made visible, in focus, or otherwise "selected". It is assumed that a FHIR resource (e.g., observation) with the specified `id` is contained in the current anchor context's content, the Hub MAY or MAY NOT provide validation of its presence.
+A `DiagnosticReport-select` request will be made to the Hub when a Subscriber desires to indicate that one or more FHIR resources contained in the DiagnosticReport context's content are to be made visible, in focus, or otherwise "selected". It is assumed that a FHIR resource (e.g., Observation) with the specified `id` is contained in the specified [`anchor context's`](5_glossary.html) content, the Hub MAY or MAY NOT provide validation of its presence.
 
 This event allows other Subscribers to adjust their UIs as appropriate.  For example, a reporting system may indicate that the user has selected a particular observation associated with a measurement value. After receiving this event an image reading application which created the measurement may wish to change its user display such that the image from which the measurement was acquired is visible.
 
@@ -12,10 +12,10 @@ If one or more resources are noted as selected, any other resource which had bee
 ### Context
 
 {:.grid}
-Key | Optionality | FHIR operation to generate context | Description
----- | ---- | ---- | ----
-`report` | REQUIRED | `DiagnosticReport/{id}?_elements=identifier` | Anchor context
-`select` | REQUIRED | not applicable | Contains zero or more references to selected resources. If a reference to a resource is present in the `select` array, there is an implicit unselect of any previously selected resource. If no resource references are present in the `select` array, this is an indication that any previously selected resource is now unselected.
+Key | Cardinality | FHIR operation to generate context | Description
+----- | -------- | ---- | ---- 
+`report` | 1..1 | `DiagnosticReport/{id}?_elements=identifier` | FHIR DiagnosticReport resource specifying the [`anchor context`](5_glossary.html) in which the selection is being made.  Note that only the resource.resourceType and resource.id of the [`anchor context`](5_glossary.html) are required to be present.
+`select` | 1..1 | not applicable | Contains zero or more references to selected resources in a `resources` array. If a reference to a resource is present in the `resources` array, there is an implicit unselect of any previously selected resource. If no resource references are present in the `resources` array, this is an indication that any previously selected resource is now unselected.
 
 ### Examples
 
@@ -26,24 +26,24 @@ The following example shows the selection of a single Observation resource in an
 ```json
 {
   "timestamp": "2019-09-10T14:58:45.988Z",
-  "id": "0e7ac18",
+  "id": "78ef1125-7f8b-4cbc-bc59-a2a02f7e04",
   "event": {
-    "hub.topic": "DrXRay",
+    "hub.topic": "fdb2f928-5546-4f52-87a0-0648e9ded065",
     "hub.event": "DiagnosticReport-select",
     "context": [
       {
         "key": "report",
         "resource": {
           "resourceType": "DiagnosticReport",
-          "id": "40012366"
+          "id": "2402d3bd-e988-414b-b7f2-4322e86c9327"
         }
       },
       {
         "key": "select",
-        "resource": [
+        "resources": [
           {
             "resourceType": "Observation",
-            "id": "a67tbi5891trw123u6f9134"
+            "id": "40afe766-3628-4ded-b5bd-925727c013b3"
           }
         ]
       }
@@ -56,5 +56,6 @@ The following example shows the selection of a single Observation resource in an
 
 {:.grid}
 | Version | Description
-| ------- | -------------
-| 0.1     | Initial draft
+| ------- | ----
+| 0.1 | Initial draft
+| 1.0 | Updated for STU3


### PR DESCRIPTION
Updated -select array holding selected resources to be `resources` rather than `resource`.

Identified inconsistencies in event documentation given recent changes to -open and -close events.  Updated documentation of -select and -update to be consistent in the look and feel of -open and -close events.