### PR TITLE
FHIR 36910 Re-open Refinement (v2)

### DIFF
--- a/input/fsh/UpdateBundle.fsh
+++ b/input/fsh/UpdateBundle.fsh
@@ -7,7 +7,7 @@ Description: """
     communicated in FHIRcast `-update` messages. The bundle can only contain
     requests of type PUT and DELETE.  
     POST is not allowed as the content sharing mechanism cannot indicate the 
-    id of the created resource.
+    id of the created resource using the POST operation.
 """
 * type MS
 * type = #transaction

--- a/input/pagecontent/2-10-1-ContentSharingFHIRcastMessaging.md
+++ b/input/pagecontent/2-10-1-ContentSharingFHIRcastMessaging.md
@@ -30,7 +30,7 @@ Support of content sharing by a Hub is optional.  If supporting content sharing,
 5. When a `[FHIR resource]-close` request is received, the Hub should dispose of the content for the current anchor context (i.e., the context being closed by this request) since the Hub has no responsibility to persist the content
 6. Forward a `[FHIR resource]-select` event to all Subscribers 
 
-A Hub is not responsible for structurally validating FHIR resources.  While a Hub must be able to successfully parse FHIR resources sufficiently to perform its required capabilities (e.g., find the `id` of a resource), a Hub is not responsible for additional structural checking.  If the Hub does not rejects an update request, for any reason, it SHALL reject the entire request - it SHALL NOT accept some changes specified in the bundle and reject others.
+A Hub is not responsible for structurally validating FHIR resources.  While a Hub must be able to successfully parse FHIR resources sufficiently to perform its required capabilities (e.g., find the `id` of a resource), a Hub is not responsible for additional structural checking.  If the Hub does reject an update request, for any reason, it SHALL reject the entire request - it SHALL NOT accept some changes specified in the bundle and reject others.
 
 A Hub is not responsible for any long-term persistence of shared information and should purge the content when a `[FHIR resource]-close` request is received.
 
@@ -55,4 +55,15 @@ If the `context.versionId` values match, the Hub proceeds with processing each o
 
 `[FHIR-resource]-update` events MAY also update attributes of the anchor context or associated context resources.  For example, a Subscriber might wish to update the `status` attribute of the anchor context resource.
 
-When a  `DiagnosticReport-update` event is received by an application, the application should respond as is appropriate for its clinical use.  For example, an image reading application may choose to ignore an observation describing a patient's blood pressure.  Since transactional change sets are used during information exchange, no problems are caused by applications deciding to ignore exchanged information not relevant to their function.  However, they should read and retain the `context.versionId` of the anchor context provided in the event for later use.
+When a `[FHIR-resource]-update` event is received by an application, the application should respond as is appropriate for its clinical use.  For example, an image reading application may choose to ignore an observation describing a patient's blood pressure.  Since transactional change sets are used during information exchange, no problems are caused by applications deciding to ignore exchanged information not relevant to their function.  However, they should read and retain the `context.versionId` of the anchor context provided in the event for later use.
+
+### Content creation and reopen scenario
+
+When a Subscriber creates a FHIR resource which it asks be added to the anchor context's content, it must create an `id` for the resource (see: [Resource.id](http://hl7.org/fhir/resource.html)).  Two approaches to populating the resource's `id` are possible:
+
+1. The Subscriber persists the resource in a FHIR server prior to adding the resource to the anchor context's content.  Since the FHIR server provides an `id` for the resource this `id` SHOULD be used for the resource's `id` when adding the resource to the anchor context's content.
+2. The resource has not yet been persisted in a FHIR server or will never be persisted in a FHIR server by the Subscriber adding the resource to the anchor context's content.  In this case, the Subscriber SHOULD use a mechanism to generate the `id` such that it will be globally unique (e.g., a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)).
+
+If the same anchor context is re-opened and used for a content sharing session, the same [Resource.id](http://hl7.org/fhir/resource.html) used during the initial content sharing session should be used by any Subscriber adding the same resource to this re-opened content sharing session.  Hence, should any Subscriber participating in a content sharing session decide to persist a resource after the content sharing session is closed, it SHOULD ensure that the original [Resource.id](http://hl7.org/fhir/resource.html) is part of the persisted resource.  This enables a Subscriber to add the resource to a re-opened content sharing session with the original [Resource.id](http://hl7.org/fhir/resource.html) or to identify (match) resources added to a re-opened content sharing session with the resource in the original content sharing session.
+
+For further discussion on the re-opening of content sharing sessions see Section [4.6 FHIRcast event-based content sharing for Radiology](4-6-fhircast-event-content-sharing.html).


### PR DESCRIPTION
Clarifications to FHIRcast Event-based Content sharing when a given anchor context is re-opened.

Replaces PR#483