### PR TITLE
FHIR-43352: Relax requirement for extensions

### DIFF
--- a/input/pagecontent/2-8-Extensions.md
+++ b/input/pagecontent/2-8-Extensions.md
@@ -1,4 +1,4 @@
-The specification is not prescriptive about support for extensions. However, to support extensions, the specification reserves the name `extension` and will never define an element with that name, allowing implementations to use it to provide custom behavior and information. The value of an extension element MUST be a valid JSON object and is typically pre-coordinated. For example, an extension on a notification could look like this:
+The specification is not prescriptive about support for extensions. However, to support extensions, the specification reserves the name `extension` and will never define an element with that name, allowing implementations to use it to provide custom behavior and information. The value of an extension element SHALL be a valid JSON object and is typically pre-coordinated. For example, an extension on a notification could look like this:
 
 ```json
 {


### PR DESCRIPTION
Currently in Extensions paragraph, the requirement for an Extension is to be "pre-coordinated". It is enough for an extension to be a valid JSON object.