### PR TITLE
add wg extension to resolve some build errors

### DIFF
--- a/input/fsh/FHIRcastDiagnosticReportSelect.fsh
+++ b/input/fsh/FHIRcastDiagnosticReportSelect.fsh
@@ -11,6 +11,8 @@ The `DiagnosticReport` in [`DiagnosticReport-select`](3-6-4-DiagnosticReport-sel
 Hence, the only required attributes of `DiagnosticReport` in the [`DiagnosticReport-select`](3-6-4-DiagnosticReport-select.html) event is the resources' `id`, as well as its `status` and `code` since these attributes are required by FHIR.  Other attributes of the `DiagnosticReport` MAY be valued but would serve no purpose in the [`DiagnosticReport-select`](3-6-4-DiagnosticReport-select.html) event.
 
 """
+* ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg"
+* ^extension[0].valueCode = #inm
 * id 1..1 
 * id ^short = "A logical id of the resource SHALL be provided."
 * id ^definition =

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,5 +1,5 @@
 {
-  "package-id" : "{pid}",
+  "package-id" : "fhircast-docs",
   "version" : "3.0.0-ballot",
   "path" : "{path}",
   "mode" : "working",

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,0 +1,11 @@
+{
+  "package-id" : "{pid}",
+  "version" : "3.0.0-ballot",
+  "path" : "{path}",
+  "mode" : "working",
+  "status" : "ballot",
+  "sequence" : "STU 3",
+  "desc" : "Reballot of FHIRcast STU3",
+  "changes" : "7_design-notes.html",
+  "first" : false,
+}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -11,8 +11,6 @@ status: draft
 extension:
   - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-wg  #<<< must include a http://hl7.org/fhir/StructureDefinition/structuredefinition-wg extension that identifies the workgroup responsible for the IG. This is the authoritative element.
     valueCode: inm  # <<< The value must be the code for the workgroup
-  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
-    valueCode: trial-use
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: 'http://unstats.un.org/unsd/methods/m49/m49.htm#001'
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -14,9 +14,9 @@ extension:
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: 'http://unstats.un.org/unsd/methods/m49/m49.htm#001'
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
-version: 3.0.0
+version: 3.0.0-ballot
 copyrightYear: 2017+
-releaseLabel: CI Build  # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: STU 3 Ballot  # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 publisher:
   name: HL7 International / Infrastructure And Messaging
   url: http://www.hl7.org/Special/committees/inm

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -8,6 +8,11 @@ name: FHIRcast
 title: FHIRcast
 description: "FHIRcast synchronizes healthcare applications in real time to show the same clinical content to a common user."
 status: draft
+extension:
+  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-wg  #<<< must include a http://hl7.org/fhir/StructureDefinition/structuredefinition-wg extension that identifies the workgroup responsible for the IG. This is the authoritative element.
+    valueCode: inm  # <<< The value must be the code for the workgroup
+  - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
+    valueCode: trial-use
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: 'http://unstats.un.org/unsd/methods/m49/m49.htm#001'
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html


### PR DESCRIPTION
When HL7 is publishing a resource, the owning committee must be stated using the http://hl7.org/fhir/StructureDefinition/structuredefinition-wg extension