### PR TITLE
Update ignoreWarnings.txt

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -24,5 +24,5 @@ Reference to draft CodeSystem http://radlex.org%
 # Informational severity; will investigate appropriate of assigning an OID, but not before ballot
 This resource could usefully have an OID assigned%
 
-#Informational severity; looking into THO processes, but not before ballot
+#TSMG has voted for this Codesystem to remain in this IG, see minutes: https://confluence.hl7.org/display/TSMG/2024-04-11+TSMG+Agenda+and+Minutes
 Most code systems defined in HL7 IGs will need to move to THO later during the process.%

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -24,5 +24,5 @@ Reference to draft CodeSystem http://radlex.org%
 # Informational severity; will investigate appropriate of assigning an OID, but not before ballot
 This resource could usefully have an OID assigned%
 
-#TSMG has voted for this Codesystem to remain in this IG, see minutes: https://confluence.hl7.org/display/TSMG/2024-04-11+TSMG+Agenda+and+Minutes
+# TSMG has voted for this Codesystem to remain in this IG, see minutes: https://confluence.hl7.org/display/TSMG/2024-04-11+TSMG+Agenda+and+Minutes
 Most code systems defined in HL7 IGs will need to move to THO later during the process.%


### PR DESCRIPTION
TSMG voted to keep this codesystem -- https://build.fhir.org/ig/HL7/fhircast-docs/CodeSystem-fhircast-codesystem.html defined within the FHIRcast IG instead of centralizing it. Minutes of vote are here: https://confluence.hl7.org/display/TSMG/2024-04-11+TSMG+Agenda+and+Minutes

subIGs will need to reference this IG to use it.

They did ask us to consider renaming it. Jira representing that ask is here: https://jira.hl7.org/browse/FHIR-45279