### PR TITLE
update fhircast capstmt extension

### DIFF
--- a/input/fsh/CapabilityStatement.fsh
+++ b/input/fsh/CapabilityStatement.fsh
@@ -18,7 +18,7 @@ Description: "CapabilityStatment stating support for FHIRcast. To supplement or 
 * rest contains client 0..1 and server 0..1
 * rest[client].mode = #client
 * rest[server].mode = #server
-* rest[server].extension contains FHIRcastConfigurationExtension named fhircast 0..1
+* rest[server].extension contains FHIRcastConfigurationExtension named fhircast 0..1 MS
 
 Extension: FHIRcastConfigurationExtension
 Id: fhircast-configuration-extension

--- a/input/fsh/CapabilityStatement.fsh
+++ b/input/fsh/CapabilityStatement.fsh
@@ -1,24 +1,24 @@
 Profile: FHIRcastCapabilityStatement
 Parent: CapabilityStatement
 Id: fhircast-capabilitystatement
-Description: "CapabilityStatment stating support for FHIRcast."
+Description: "CapabilityStatment stating support for FHIRcast. To supplement or optionally identify the location of a FHIRcast hub, a FHIR server MAY declare support for FHIRcast using the FHIRcast extension on its FHIR CapabilityStatement’s rest element."
 * ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg"
 * ^extension[0].valueCode = #inm
 * implementationGuide ^slicing.rules = #open
-* implementationGuide ^slicing.description = "Requires FHIRcast IG to be listed"
+* implementationGuide ^slicing.description = "Encourage FHIRcast IG to be listed"
 * implementationGuide ^slicing.discriminator.type = #value
 * implementationGuide ^slicing.discriminator.path = "$this"
-* implementationGuide 1..*
-* implementationGuide contains fhircast 1..1
+* implementationGuide 0..*
+* implementationGuide contains fhircast 0..1
 * implementationGuide[fhircast] = "http://hl7.org/fhir/uv/fhircast/ImplementationGuide/hl7.fhir.uv.fhircast|3.0.0"
 * rest ^slicing.rules = #open
 * rest ^slicing.discriminator.type = #value
 * rest ^slicing.discriminator.path = "mode"
-* rest ^slicing.description = "Slice stating support for FHIRcast extension"
+* rest ^slicing.description = "Slice stating support for FHIRcast extension. Note that this extension might not be supportable by client-side Hubs."
 * rest contains client 0..1 and server 0..1
 * rest[client].mode = #client
 * rest[server].mode = #server
-* rest[server].extension contains FHIRcastConfigurationExtension named fhircast 0..1 MS
+* rest[server].extension contains FHIRcastConfigurationExtension named fhircast 0..1
 
 Extension: FHIRcastConfigurationExtension
 Id: fhircast-configuration-extension

--- a/input/pagecontent/2-7-Conformance.md
+++ b/input/pagecontent/2-7-Conformance.md
@@ -46,37 +46,8 @@ Content-Type: application/json
 
 ### FHIR Capability Statement
 
-To supplement or optionally identify the location of a FHIRcast hub, a FHIR server MAY declare support for FHIRcast using the FHIRcast extension on its FHIR CapabilityStatement's `rest` element. The FHIRcast extension has the following internal extensions:
+To supplement or optionally identify the location of a FHIRcast hub, a FHIR server MAY declare support for FHIRcast using the FHIRcast extension on its FHIR CapabilityStatement's `rest` element. Note that client-side Hubs without a client-side FHIR server likely will not support communicating the url of a hub in this extension. See [the FHIRcast CapabilityStatement profile](StructureDefinition-fhircast-capabilitystatement.html).
 
-{:.grid}
-Extension | Cardinality | Type | Description
---- | --- | --- | ---
-`hub.url`| 0..1 | url | The url at which an application can subscribe. This might not be supported by client-side Hubs.
-
-#### CapabilityStatement Extension Example 
-
-```text
-{
-  "resourceType": "CapabilityStatement",
-  ....
-  "rest": [{
-   ...
-        "extension": [
-          {
-            "url": "http://fhircast.hl7.org/StructureDefinition/fhircast-configuration/fhir-configuration",
-            "extension": [
-              {
-                "url": "hub.url",
-                "valueUri": "https://hub.example.com/fhircast/hub/R4"
-              }
-            ]
-          }
-        ]      
-    ...
-    }]
-    ...
-}
-```
 ### FHIR Resource Structures
 
 FHIRcast defines profiles for various FHIR resource structures used in the specification, see [`summary of artifacts`](artifacts.html).


### PR DESCRIPTION
to make it more consistent with pre-existing mandatory language, and to enable the possibility of client-side Hubs, and to not mandate declaring support for FHRIcast in the CapStmt.