### PR TITLE
Fix SUSHI / IG validation to run in forks as well

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,9 @@ name: validate
 
 on:
   push:
+    branches: [ master ]
+  pull_request:
+    types: [opened, synchronize] # This will trigger the workflow only when a PR is opened or updated with new commits
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Previous triggers didn't run for PRs created in forks (such as [this one](https://github.com/HL7/fhircast-docs/pull/574)) - this PR fixes it.

Just a note that the first time someone contributes to the repository, you'll need to [manually approve](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) the checks to run as a safety measure.