### PR TITLE
FHIR 45719 Fix Main Issue of Ticket

### DIFF
--- a/input/pagecontent/3-6-3-DiagnosticReport-update.md
+++ b/input/pagecontent/3-6-3-DiagnosticReport-update.md
@@ -15,8 +15,8 @@ The updates include:
 Key | Cardinality | Description
 ----- | -------- | ---- 
 `report` | 1..1 | FHIR DiagnosticReport resource specifying the [`anchor context`](5_glossary.html) in which the update is being made.  Note the mandatory elements defined in the [DiagnosticReport update profile](StructureDefinition-fhircast-diagnostic-report-update.html). Other attributes may be present in the DiagnosticReport resource if their values have changed or were newly populated.
-`patient` | 0..1 | Present if one or more attributes in the Patient resource associated with the report have changed.
-`study` | 0..1 | Present if one or more attributes in the ImagingStudy resource associated with the report have changed
+`patient` | 0..1 | Present if one or more attributes in the Patient resource associated with the report have changed
+`study` | 0..* | Present if one or more attributes in an ImagingStudy resource associated with the report have changed
 `updates` | 1..1 | Contains a single `Bundle` resource holding changes to be made to the current content of the [`anchor context`](5_glossary.html)
 
 The following profiles provide guidance as to which resource attributes should be present and considerations as to how each attribute should be valued in a DiagnosticReport-update request:


### PR DESCRIPTION
Fix the original issue noted in Jira 45719 which was that the study attribute in the context was noted as 0..1; however, the proper documentation should be that there may be 0 to n study resources in the context array. 